### PR TITLE
people index - fixed courses and website structures

### DIFF
--- a/ingest/ingest-people.py
+++ b/ingest/ingest-people.py
@@ -250,12 +250,33 @@ def get_email(person):
         .one().value
 
 def get_website(person):
-    return Maybe.of(person).stream() \
+    weblinks = []
+
+    websites = Maybe.of(person).stream() \
         .flatmap(lambda p: p.objects(OBO.ARG_2000028)) \
         .flatmap(lambda v: v.objects(VCARD.hasURL)) \
-        .flatmap(lambda e: e.objects(VCARD.url)) \
-        .filter(non_empty_str) \
-        .one().value
+        .filter(lambda o: has_type(o,VCARD.URL)).list()
+
+    for website in websites:
+        print("website", website )
+
+        webname = Maybe.of(website).stream() \
+           .filter(has_label) \
+           .map(lambda t: str(t.label())) \
+           .filter(non_empty_str) \
+           .one().value[0]
+        print("webname", webname)
+
+        weburl = Maybe.of(website).stream() \
+           .flatmap(lambda e: e.objects(VCARD.url)) \
+           .map(lambda r: r.value) \
+           .one().value
+        print("weburl", weburl)
+
+        if weburl:
+           weblinks.append({"name": webname, "uri": weburl})
+
+    return weblinks
 
 
 def get_research_areas(person):
@@ -338,7 +359,8 @@ def get_courses(coursesgraph):
             .one().value
         if course:
             print("course exists: ", course)
-            courses.append({"course": course})
+#            courses.append({"course": course})
+            courses.append(course)
 
     return courses
 

--- a/ingest/ingest-people.py
+++ b/ingest/ingest-people.py
@@ -349,8 +349,8 @@ def get_courses(coursesgraph):
 #    print("got instructors: ", instructors)
 
     for instructor in instructors:
-        print("in instructor loop")
-        print("instructor: ", instructor)
+#        print("in instructor loop")
+#        print("instructor: ", instructor)
 
         course = Maybe.of(instructor).stream() \
             .flatmap(lambda o: o.objects(OBO.BFO_0000054)) \
@@ -358,8 +358,7 @@ def get_courses(coursesgraph):
             .map(lambda o: {"uri": str(o.identifier), "name": o.label()[0:o.label().find(" -")]}) \
             .one().value
         if course:
-            print("course exists: ", course)
-#            courses.append({"course": course})
+#            print("course exists: ", course)
             courses.append(course)
 
     return courses
@@ -368,13 +367,13 @@ def get_courses(coursesgraph):
 def get_awards(awardgraph):
     awards = []
 
-    print("In get_awards")
+#    print("In get_awards")
 
     receipts = Maybe.of(awardgraph).stream() \
         .flatmap(lambda per: per.objects(VIVO.relatedBy)) \
         .filter(lambda related: has_type(related, VIVO.AwardReceipt)).list()
 
-    print("got award receipts")
+#    print("got award receipts")
 
     for receipt in receipts:
 #        print("in award receipt loop")
@@ -576,9 +575,9 @@ def publish(bulk, endpoint, rebuild, mapping):
         print "putting map file"
         if r.status_code != requests.codes.ok:
             print r.status_code, r.content
+
             # new mapping may be incompatible with previous
             # delete current mapping and re-push
-
             requests.delete(mapping_url, verify=False)
             print "failed. deleting..."
             r = requests.put(mapping_url, data=mapping_file, verify=False)


### PR DESCRIPTION
Modified website structure to return a structure of label + uri
This is because the vcard URL is also used to hold social media links.
The label is used to determine what type of weblink is being returned

Courses taught structure had "courses" as a key which is redundant AND also inconsistent with all other types being returned. Found this when working through the html to display it.
Fixed this.

Tested on dev