### PR TITLE
Expdir 151

### DIFF
--- a/ingest/.vscode/launch.json
+++ b/ingest/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Current File",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal",
+            "args": ["--index","fispubs", "--sparql","https://vivo-cub-staging.colorado.edu/api/sparqlQuery", "pubs.idx"]
+        },
+        {
+            "name": "Python: ingest-people.py",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/ingest-people.py",
+            "console": "integratedTerminal",
+            "args": ["people.idx"]
+        }
+    ]
+}

--- a/ingest/.vscode/settings.json
+++ b/ingest/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "python.pythonPath": "/usr/bin/python",
+    "python.linting.pylintEnabled": true,
+    "python.linting.enabled": true
+}

--- a/ingest/load-data.py
+++ b/ingest/load-data.py
@@ -9,24 +9,28 @@ import json
 import os, time
 import argparse
 
+## Parse and set parameter values
+
 parser = argparse.ArgumentParser()
 parser.add_argument('--spooldir', default='./spool', help='where to read files from')
+parser.add_argument('--esendpoint', default='search-experts-pubs-unoedenr36fpm7alfpboeihcnq.us-east-2.es.amazonaws.com', help='AWS Elasticsearch enddpoint')
+parser.add_argument('--esservice', default='es', help='AWS Elastic enddpoint service')
+parser.add_argument('--esregion', default='us-east-2', help='AWS Elasticsearch enddpoint region')
+parser.add_argument('--index', default='fispubs', help='Elasticsearch index name')
 parser.add_argument('out', metavar='OUT', help='elasticsearch bulk ingest file format eg allpubs.idx')
 args = parser.parse_args()
 
 bulkfiles=args.spooldir + '/' + args.out + '*'
-#index="fispubs-setup-news"
-index="fispubs"
+index=args.index
+host = args.esendpoint
+service = args.esservice
+region = args.esregion
 
-
-
-host = 'search-experts-pubs-unoedenr36fpm7alfpboeihcnq.us-east-2.es.amazonaws.com'
-service = 'es'
-region = 'us-east-2'
+#Setup AWS Elastic Authentication. 
+# The credential needs to be placed in the .aws directory under the home directory of the user running this. Similar to .ssh
 
 credentials = boto3.Session().get_credentials()
 awsauth = AWS4Auth(credentials.access_key, credentials.secret_key, region, service, session_token=credentials.token)
-
 es = Elasticsearch(
     hosts = [{'host': host, 'port': 443}],
     http_auth = awsauth,
@@ -34,15 +38,16 @@ es = Elasticsearch(
     verify_certs = True,
     connection_class = RequestsHttpConnection
 )
+
 # Example of a single document upload, for future
 #doc = {
 #    'author': 'kimchy2',
 #    'text': 'Elasticsearch: cool. bonsai cool.',
 #    'timestamp': datetime.now(), 
 #         }
-
 #res = es.index(index="test-index", id=2, body=doc)
 #print(res['result'])
+
 
 es.indices.delete(index=index, ignore=[400, 404])
 

--- a/ingest/load-data.py
+++ b/ingest/load-data.py
@@ -1,0 +1,46 @@
+from elasticsearch import Elasticsearch, RequestsHttpConnection
+from elasticsearch.helpers import parallel_bulk
+from collections import deque
+from requests_aws4auth import AWS4Auth
+from datetime import datetime
+import boto3
+import glob
+import json
+import os, time
+
+#index="fispubs-setup-news"
+index="fispubs"
+
+
+
+host = 'search-experts-pubs-unoedenr36fpm7alfpboeihcnq.us-east-2.es.amazonaws.com'
+service = 'es'
+region = 'us-east-2'
+
+credentials = boto3.Session().get_credentials()
+awsauth = AWS4Auth(credentials.access_key, credentials.secret_key, region, service, session_token=credentials.token)
+
+es = Elasticsearch(
+    hosts = [{'host': host, 'port': 443}],
+    http_auth = awsauth,
+    use_ssl = True,
+    verify_certs = True,
+    connection_class = RequestsHttpConnection
+)
+doc = {
+    'author': 'kimchy2',
+    'text': 'Elasticsearch: cool. bonsai cool.',
+    'timestamp': datetime.now(), 
+         }
+
+res = es.index(index="test-index", id=2, body=doc)
+print(res['result'])
+
+es.indices.delete(index=index, ignore=[400, 404])
+
+for f in glob.iglob('spool/pubs.idx*'):
+  print(f)
+  with open(f) as json_file:
+    json_docs=json_file.read()
+    es.bulk(json_docs)
+    time.sleep(5)

--- a/ingest/rebuild-pubs-aws.sh
+++ b/ingest/rebuild-pubs-aws.sh
@@ -6,7 +6,7 @@ mkdir $outdir
 logfile="${outdir}/rebuild-pubs.out"
 echo "CREATING ES DOCUMENTS"  > $logfile
 echo "Starttime: $dstamp" >> $logfile
-echo $MINPUBSCOUNT
+echo $MINPUBSCOUNT >> $logfile
 python ./ingest-publications.py --index ${PUBSINDEX} --sparql ${ENDPOINT} --threads 10 --spooldir ${outdir} allpubs.idx   >> $logfile 2>&1
 EXITCODE=$?
 if [ $EXITCODE -ne 0 ]
@@ -18,7 +18,7 @@ fi
 echo "Ingest-publications finished: `date +%Y%m%d-%H%M%S`" >> $logfile 2>&1
 
 outputsize=`wc -l ${outdir}/full-allpubs.idx | awk  '{print $1}'`
-echo "$outputsize lines in ${outdir}/full-allpubs.idx"
+echo "$outputsize lines in ${outdir}/full-allpubs.idx" >> $logfile
 if [ $outputsize -lt $MINPUBSCOUNT ]
 then
   echo "Not enough lines in output. Amount of lines: $outputsize. File: ${outdir}/full-allpubs.idx" >>$logfile 2>&1
@@ -27,7 +27,7 @@ then
 fi
 
 ./idx_get_count.sh $indexname >> $logfile
-python load-data.py --spooldir ${outdir} --esendpoint ${ESENDPOINT} --esservice ${ESSERVICE} --esregion ${ESREGION} --index ${PUBSINDEX} allpubs.idx
+python load-data.py --spooldir ${outdir} --esendpoint ${ESENDPOINT} --esservice ${ESSERVICE} --esregion ${ESREGION} --index ${PUBSINDEX} allpubs.idx >> $logfile 2>&1
 
 sleep 5 
 echo "load-data.py finished: `date +%Y%m%d-%H%M%S`" >> $logfile 2>&1

--- a/ingest/rebuild-pubs-aws.sh
+++ b/ingest/rebuild-pubs-aws.sh
@@ -4,28 +4,32 @@ dstamp=`date +%Y%m%d-%H%M%S`
 outdir="spool/${dstamp}"
 mkdir $outdir
 logfile="${outdir}/rebuild-pubs.out"
-echo "CREATING ES DOCUMENTS" # > $logfile
-python ./ingest-publications.py --index ${indexname} --sparql ${ENDPOINT} --threads 10 --spooldir ${outdir} allpubs.idx   >> $logfile 2>&1
+echo "CREATING ES DOCUMENTS"  > $logfile
+echo "Starttime: $dstamp" >> $logfile
+echo $MINPUBSCOUNT
+python ./ingest-publications.py --index ${PUBSINDEX} --sparql ${ENDPOINT} --threads 10 --spooldir ${outdir} allpubs.idx   >> $logfile 2>&1
 EXITCODE=$?
 if [ $EXITCODE -ne 0 ]
 then
-  echo "NON ZERO EXITCODE: $EXITCODE" >>$logfile 2>&1
-  cat $logfile | mailx -s "ERROR: rebuild-pubs.sh - error in ingest-publications.py" elsborg@colorado.edu
+  echo "NON ZERO EXITCODE: $EXITCODE" >> $logfile 2>&1
+  cat $logfile | mailx -s "ERROR: rebuild-pubs.sh - error in ingest-publications.py" $NOTIFYEMAIL
   exit
 fi
+echo "Ingest-publications finished: `date +%Y%m%d-%H%M%S`" >> $logfile 2>&1
 
 outputsize=`wc -l ${outdir}/full-allpubs.idx | awk  '{print $1}'`
 echo "$outputsize lines in ${outdir}/full-allpubs.idx"
-if [ $outputsize -lt 75 ]
+if [ $outputsize -lt $MINPUBSCOUNT ]
 then
   echo "Not enough lines in output. Amount of lines: $outputsize. File: ${outdir}/full-allpubs.idx" >>$logfile 2>&1
-  cat $logfile | mailx -s "ERROR: rebuild-pubs.sh - not enough lines in json file" elsborg@colorado.edu
+  cat $logfile | mailx -s "ERROR: rebuild-pubs.sh - not enough lines in json file" $NOTIFYEMAIL
   exit
 fi
 
 ./idx_get_count.sh $indexname >> $logfile
-python load-data.py --spooldir ${outdir} allpubs.idx
+python load-data.py --spooldir ${outdir} --esendpoint ${ESENDPOINT} --esservice ${ESSERVICE} --esregion ${ESREGION} --index ${PUBSINDEX} allpubs.idx
 
 sleep 5 
+echo "load-data.py finished: `date +%Y%m%d-%H%M%S`" >> $logfile 2>&1
 echo "Index counts after run" >> $logfile
 ./idx_get_count.sh $indexname >> $logfile 2>&1

--- a/ingest/rebuild-pubs.sh
+++ b/ingest/rebuild-pubs.sh
@@ -10,16 +10,16 @@ EXITCODE=$?
 if [ $EXITCODE -ne 0 ]
 then
   echo "NON ZERO EXITCODE: $EXITCODE" >>$logfile 2>&1
-  cat $logfile | mailx -s "ERROR: rebuild-pubs.sh - error in ingest-publications.py" elsborg@colorado.edu
+  cat $logfile | mailx -s "ERROR: rebuild-pubs.sh - error in ingest-publications.py" $NOTIFYEMAIL
   exit
 fi
 
 outputsize=`wc -l ${outdir}/full-allpubs.idx | awk  '{print $1}'`
 echo "$outputsize lines in ${outdir}/full-allpubs.idx"
-if [ $outputsize -lt 75000 ]
+if [ $outputsize -lt $MINPUBSCOUNT ]
 then
   echo "Not enough lines in output. Amount of lines: $outputsize. File: ${outdir}/full-allpubs.idx" >>$logfile 2>&1
-  cat $logfile | mailx -s "ERROR: rebuild-pubs.sh - not enough lines in json file" elsborg@colorado.edu
+  cat $logfile | mailx -s "ERROR: rebuild-pubs.sh - not enough lines in json file" $NOTIFYEMAIL
   exit
 fi
 

--- a/ingest/rebuild-pubs.sh
+++ b/ingest/rebuild-pubs.sh
@@ -25,15 +25,29 @@ fi
 
 echo "Index counts prior to run" >> $logfile
 ./idx_get_count.sh $indexname >> $logfile
-curl -XDELETE localhost:9200/${indexname} >> $logfile
+sleep 1
+echo " " >> $logfile
+echo -e "\nDeleting Old Index: ${indexname}" >> $logfile
+curl -XDELETE localhost:9200/${indexname} >> $logfile 2>&1
+sleep 1
+echo "" >> $logfile
+echo -e "\nCreating new Index: ${indexname}" >> $logfile
 curl -XPUT localhost:9200/${indexname} >> $logfile
-curl -XPUT -H 'Content-Type: application/json' localhost:9200/${indexname}/publication/_mapping?pretty --data-binary @mappings/publication.json >> $logfile
+sleep 1
+# Don't need mapping for now
+#echo " " >> $logfile
+#echo -e "\nAdding mapping to Index: ${indexname}" >> $logfile
+#curl -XPUT -H 'Content-Type: application/json' localhost:9200/${indexname}/publication/_mapping?pretty --data-binary @mappings/publication.json >> $logfile
+#sleep 1
+echo " " >> $logfile
+echo -e "\nUploading bulk files to Index: ${indexname}" >> $logfile
 for f in $outdir/allpubs.idx*
 do 
-   echo $f 
+   echo "" >> $logfile
+   echo -e "\nLoading file: $f" >> $logfile 
    curl -XPUT -H 'Content-Type: application/json' 'localhost:9200/_bulk' --data-binary @$f >> $logfile 2>&1
+   sleep 1
 done
-
-sleep 10
+echo "" >> $logfile
 echo "Index counts after run" >> $logfile
 ./idx_get_count.sh $indexname >> $logfile 2>&1

--- a/ingest/reload-pubs-aws.sh
+++ b/ingest/reload-pubs-aws.sh
@@ -1,7 +1,7 @@
 . ./vivoapipw.py
 indexname=$PUBSINDEX
 dstamp=`date +%Y%m%d-%H%M%S`
-dstamp="20200825-164856"
+dstamp="20200827-160528"
 outdir="spool/${dstamp}"
 #mkdir $outdir
 outfile="${outdir}/reload-pubs.out"
@@ -10,7 +10,8 @@ echo "Files in $outdir"
 echo "Index counts prior to run" 
 ./idx_get_count.sh $indexname 
 
-python ./load-data.py --spooldir ${outdir}  allpubs.idx
+python ./load-data.py --spooldir ${outdir} --esendpoint ${ESENDPOINT} --esservice ${ESSERVICE} --esregion ${ESREGION} --index ${PUBSINDEX} allpubs.idx
+
 
 sleep 1
 echo "Index counts after run"

--- a/ingest/vivoapipw.py.example
+++ b/ingest/vivoapipw.py.example
@@ -1,9 +1,14 @@
 #Entries to access to vivo sparql update api
 # Copy this to vivoapipw.py and modify the entries
 # This file is used by both the bash shell scripts and the python ingest scripts
-EMAIL='my.email@yourschool.edu'
-PASSWORD='somecrazysecurepassword'
-ENDPOINT='http://yourschool.edu/vivo/api/sparqlQuery'
+EMAIL='VIVO SPARQL login. eg: my.email@yourschool.edu'
+PASSWORD='VIVO SPARQL password. eg: somecrazysecurepassword'
+ENDPOINT='VIVO SPARQL API endpoint. eg: http://yourschool.edu/vivo/api/sparqlQuery'
 PEOPLEINDEX='people'
 PUBSINDEX='pubs'
 ALTMETRIC_API_KEY='8k39sdkakl349skkjsomeotherkeycausethisaintreal'
+ESENDPOINT='some elastic endpoint'
+ESSERVICE='AWS service if using AWS Elastic - eg: es'
+ESREGION='AWS region if using AWS Elastic - eg: us-east-2'
+MINPUBSCOUNT='what is in the minimum amount of pubs you expect to not throw an error. eg: 75000'
+NOTIFYEMAIL"who to notify if errors: eg: fis-critical@colorado.edu"


### PR DESCRIPTION
Fulfills ticket https://cu-oda.atlassian.net/browse/EXPDIR-151

This enables chunking of data to be uploaded into an Elasticsearch endpoint.

Additionally, new files are added to support uploads to AWS Elasticsearch.
These are
load-data.py - the file which scrolls through input files and uploads them to AWS Elasticsearch
rebuild-pubs-aws.sh - Calls the publication rebuild pipleline and uploads to AWS
reload-pubs-aws.sh - The reload scripts take a hard coded spool directory and uploads the data, it bypasses the Extract and Transform from the Experts triplestore

This has been fully tested against the current Experts development and test pipeline
It has also been tested on Cythna, pulling from production vivo-cub-staging triplestore, and uploading to an AWS Elastic index.