### PR TITLE
Engfis 715

### DIFF
--- a/ingest/ingest-people.py
+++ b/ingest/ingest-people.py
@@ -77,7 +77,12 @@ def load_file(filepath):
     with open(filepath) as _file:
         return _file.read().replace('\n', " ")
 
-
+# test and set PRODURL and TARGETURL
+try:
+  PRODURL
+except NameError:
+  PRODURL="experts.colorado.edu"
+  TARGETURL="experts.colorado.edu"
 SYSTEM_NAME = socket.gethostname()
 if '-dev' in SYSTEM_NAME:
    BASE_URL = 'https://vivo-cub-dev.colorado.edu/individual'

--- a/ingest/ingest-people.py
+++ b/ingest/ingest-people.py
@@ -494,7 +494,7 @@ def create_person_doc(person, endpoint):
 
     logging.debug('check fisid: %s', person)
     fis = get_fisid(per)
-    doc = {"uri": person, "name": name, "fisId": fis}
+    doc = {"uri": person.replace(PRODURL, TARGETURL), "name": name, "fisId": fis}
 
     logging.debug('check orcid: %s', person)
     orcid = get_orcid(per)
@@ -540,6 +540,7 @@ def create_person_doc(person, endpoint):
     thumbnail = get_thumbnail(per)
     if thumbnail:
         thumbnail = thumbnail.replace("http://", "https://")
+        thumbnail = thumbnail.replace(PRODURL, TARGETURL)
         doc.update({"thumbnail": thumbnail})
 
     affiliations = get_affiliations(per)

--- a/ingest/vivoapipw.py.example
+++ b/ingest/vivoapipw.py.example
@@ -12,3 +12,6 @@ ESSERVICE='AWS service if using AWS Elastic - eg: es'
 ESREGION='AWS region if using AWS Elastic - eg: us-east-2'
 MINPUBSCOUNT='what is in the minimum amount of pubs you expect to not throw an error. eg: 75000'
 NOTIFYEMAIL"who to notify if errors: eg: fis-critical@colorado.edu"
+# The next two variables are used to swap URLS for the thumbnail and image in the people index so facetview can render the objects ot the correct URL
+PRODURL="experts.colorado.edu"
+TARGETURL="vivo-cub-dev.colorado.edu"


### PR DESCRIPTION
Simple fix to allow dev, test, setup Experts instances have the people page render a thumbnail and a person link to the local system instead of the default URL, which is experts.colorado.edu
The settings are placed in the local configuration file.
The vivpapipw.py.example file is updated to show the syntax.

Additionally, if the variables aren't set in the config file, a default value of experts.colorado.edu is place in PRODURL and TARGETURL. 

I've taken a lazy approach at this juncture because once AWS Elastic becomes the primary endpoint, I want to modularize the code more and will then address this issue in a more comprehensive manner.

This was tested in vivo