### PR TITLE
Engfis 739

### DIFF
--- a/ingest/ingest-publications.py
+++ b/ingest/ingest-publications.py
@@ -40,6 +40,8 @@ FOAF = Namespace("http://xmlns.com/foaf/0.1/")
 FIS = Namespace("https://experts.colorado.edu/individual")
 NET_ID = Namespace("http://vivo.mydomain.edu/ns#")
 PUBS = Namespace("https://experts.colorado.edu/ontology/pubs#")
+EVENT = Namespace("http://purl.org/NET/c4dm/event.owl#")
+
 
 # standard filters
 non_empty_str = lambda s: True if s else False
@@ -239,17 +241,17 @@ def create_publication_doc(pubgraph,publication):
     ams = 0
     if doi:
         doc.update({"doi": doi})
-        j = get_altmetric_for_doi(ALTMETRIC_API_KEY, doi)
-        try:
-           j
-        except NameError:
-           logging.info('No altmetric results for doi %s', pubid)
-        else:
-           logging.debug('altmetric returned %s', doi)
-           if isinstance(j, dict):
-             if 'score' in j:
-               ams = j['score']
-               doc.update({"amscore": ams})
+#DRE        j = get_altmetric_for_doi(ALTMETRIC_API_KEY, doi)
+#DRE        try:
+#DRE           j
+#DRE        except NameError:
+#DRE           logging.info('No altmetric results for doi %s', pubid)
+#DRE        else:
+#DRE           logging.debug('altmetric returned %s', doi)
+#DRE           if isinstance(j, dict):
+#DRE             if 'score' in j:
+#DRE               ams = j['score']
+#DRE               doc.update({"amscore": ams})
              #DRE - for news -- doc.update({"altmetric": j})
 
     cuscholar = list(pub.objects(predicate=PUBS.cuscholar))
@@ -289,6 +291,74 @@ def create_publication_doc(pubgraph,publication):
     if volume:
         doc.update({"volume": volume})
 
+    number = list(pub.objects(predicate=BIBO.number))
+    volume = number[0].encode('utf-8') if number else None
+    if number:
+        doc.update({"articleNumber": number})
+
+    isbn10 = list(pub.objects(predicate=BIBO.isbn10))
+    isbn10 = isbn10[0].encode('utf-8') if isbn10 else None
+    if isbn10:
+        doc.update({"isbn10": isbn10})
+
+    isbn13 = list(pub.objects(predicate=BIBO.isbn13))
+    isbn13 = isbn13[0].encode('utf-8') if isbn13 else None
+    if isbn13:
+        doc.update({"isbn13": isbn13})
+
+    eissn = list(pub.objects(predicate=BIBO.eissn))
+    eissn = eissn[0].encode('utf-8') if eissn else None
+    if eissn:
+        doc.update({"eissn": eissn})
+
+    issn = list(pub.objects(predicate=BIBO.issn))
+    issn = issn[0].encode('utf-8') if issn else None
+    if issn:
+        doc.update({"issn": issn})
+
+    pageStart = list(pub.objects(predicate=BIBO.pageStart))
+    pageStart = pageStart[0].encode('utf-8') if pageStart else None
+    if pageStart:
+        doc.update({"pageStart": pageStart})
+
+    pageEnd = list(pub.objects(predicate=BIBO.pageEnd))
+    pageEnd = pageEnd[0].encode('utf-8') if pageEnd else None
+    if pageEnd:
+        doc.update({"pageEnd": pageEnd})
+
+    dataSource = list(pub.objects(predicate=PUBS.dataSource))
+    dataSource = dataSource[0].encode('utf-8') if dataSource else None
+    if dataSource:
+        doc.update({"dataSource": dataSource})
+
+    dateInCube = list(pub.objects(predicate=PUBS.dateInCube))
+    dateInCube = dateInCube[0].encode('utf-8') if dateInCube else None
+    if dateInCube:
+        doc.update({"dateInCube": dateInCube})
+
+    authorCount = list(pub.objects(predicate=PUBS.authorCount))
+    authorCount = authorCount[0].encode('utf-8') if authorCount else None
+    if authorCount:
+        doc.update({"authorCount": authorCount})
+
+    citationCount = list(pub.objects(predicate=PUBS.citationCount))
+    citationCount = citationCount[0].encode('utf-8') if citationCount else None
+    if citationCount:
+        doc.update({"citationCount": citationCount})
+
+    fundingAcknowledgement = list(pub.objects(predicate=PUBS.fundingAcknowledgement))
+    fundingAcknowledgement = fundingAcknowledgement[0].encode('utf-8') if fundingAcknowledgement else None
+    if fundingAcknowledgement:
+        doc.update({"fundingAcknowledgement": fundingAcknowledgement})
+
+    conference = list(pub.objects(BIBO.presentedAt))
+    conference = conference[0] if conference else None
+    if conference and conference.label():
+        doc.update({"presentedAt": {"uri": conference.identifier, "name": conference.label().encode('utf8')}})
+    elif conference:
+        logging.info('conference missing label: %s', conference.identifier)
+
+
     citedAuthors = list(pub.objects(predicate=PUBS.citedAuthors))
     citedAuthors = citedAuthors[0].encode('utf-8') if citedAuthors else None
     if citedAuthors:
@@ -320,7 +390,7 @@ def create_publication_doc(pubgraph,publication):
         doc.update({"publishedIn": {"uri": venue.identifier, "name": venue.label().encode('utf8')}})
     elif venue:
         logging.info('venue missing label: %s', venue.identifier)
-
+	
     authors = []
     for s, p, o in pubgraph.triples((None, VIVO.relates, None)):
        for a, b, c in g1.triples((o, RDF.type, FOAF.Person)):

--- a/ingest/ingest-publications.py
+++ b/ingest/ingest-publications.py
@@ -326,10 +326,10 @@ def create_publication_doc(pubgraph,publication):
     if pageEnd:
         doc.update({"pageEnd": pageEnd})
 
-    dataSource = list(pub.objects(predicate=PUBS.dataSource))
-    dataSource = dataSource[0].encode('utf-8') if dataSource else None
-    if dataSource:
-        doc.update({"dataSource": dataSource})
+#DRE    dataSource = list(pub.objects(predicate=PUBS.dataSource))
+#DRE    dataSource = dataSource[0].encode('utf-8') if dataSource else None
+#DRE    if dataSource:
+#DRE        doc.update({"dataSource": dataSource})
 
     dateInCube = list(pub.objects(predicate=PUBS.dateInCube))
     dateInCube = dateInCube[0].encode('utf-8') if dateInCube else None
@@ -346,10 +346,10 @@ def create_publication_doc(pubgraph,publication):
     if citationCount:
         doc.update({"citationCount": citationCount})
 
-    fundingAcknowledgement = list(pub.objects(predicate=PUBS.fundingAcknowledgement))
-    fundingAcknowledgement = fundingAcknowledgement[0].encode('utf-8') if fundingAcknowledgement else None
-    if fundingAcknowledgement:
-        doc.update({"fundingAcknowledgement": fundingAcknowledgement})
+#DRE    fundingAcknowledgement = list(pub.objects(predicate=PUBS.fundingAcknowledgement))
+#DRE    fundingAcknowledgement = fundingAcknowledgement[0].encode('utf-8') if fundingAcknowledgement else None
+#DRE    if fundingAcknowledgement:
+#DRE        doc.update({"fundingAcknowledgement": fundingAcknowledgement})
 
     conference = list(pub.objects(BIBO.presentedAt))
     conference = conference[0] if conference else None

--- a/ingest/queries/listPubs.rq
+++ b/ingest/queries/listPubs.rq
@@ -30,11 +30,24 @@ CONSTRUCT
     ?publication vivo:hasPublicationVenue ?venue .
     ?venue rdfs:label ?venueLabel .
     ?publication bibo:pageEnd ?pageend .
-     ?publication bibo:pageStart ?pagestart .
-     ?publication bibo:issue ?issue .
-     ?publication bibo:numPages ?numpages .
-     ?publication bibo:volume ?volume .
-     ?publication pubs:citedAuthors ?authors .
+    ?publication bibo:pageStart ?pagestart .
+    ?publication bibo:issue ?issue .
+    ?publication bibo:numPages ?numpages .
+    ?publication bibo:volume ?volume .
+    ?publication pubs:citedAuthors ?authors .
+    ?publication bibo:isbn13 ?isbn13 .
+    ?publication bibo:isbn10 ?isbn10 .
+    ?publication bibo:issn ?issn .
+    ?publication bibo:eissn ?eissn .
+    ?publication bibo:number ?articlenumber .
+    ?publication pubs:dataSource ?datasource .
+    ?publication pubs:authorCount ?authorcount .
+    ?publication pubs:citationCount ?citationcount .
+    ?publication pubs:dateInCube ?dateincube .
+    ?publication pubs:fundingAcknowledgement ?fundingacknowledgement .
+    ?publication bibo:presentedAt ?conference .
+    ?conference rdf:type bibo:Conference .
+    ?conference rdfs:label ?nameofconference .
 }
 WHERE
 {
@@ -60,5 +73,19 @@ WHERE
    OPTIONAL { ?publication vivo:hasPublicationVenue ?venue .
               ?venue rdfs:label ?venueLabel
             }
+ OPTIONAL { ?publication bibo:isbn13 ?isbn13 }
+ OPTIONAL { ?publication bibo:isbn10 ?isbn10 }
+ OPTIONAL { ?publication bibo:number ?articlenumber }
+ OPTIONAL { ?publication bibo:issn ?issn }
+ OPTIONAL { ?publication bibo:eissn ?eissn }
+ OPTIONAL { ?publication pubs:dataSource ?datasource }
+ OPTIONAL { ?publication pubs:authorCount ?authorcount }
+ OPTIONAL { ?publication pubs:citationCount ?citationcount }
+ OPTIONAL { ?publication pubs:dateInCube ?dateincube }
+ OPTIONAL { ?publication pubs:fundingAcknowledgement ?fundingacknowledgement }
+ OPTIONAL { ?publication bibo:presentedAt ?conference .
+            ?conference rdf:type bibo:Conference .
+            ?conference rdfs:label ?nameofconference .
+ }
 }
 


### PR DESCRIPTION
This accomplishes a couple of things:
1. It comments out the altmetric API hit in the current ingest-publications.py which runs on the RHEL6 prometheus system.
This is because prometheus uses the old python 2.6 libraries which don't support SSL required by altmetric. The code also hangs.
Additionally, as the Elastic indexes migrate from Prometheus to AWS elastic, a new set of python scripts with "aws" in the name will be used.
2. Fields required by CIRES are included in the index now. The exceptions currently are fundingAcknowledgement and dataSource which are commented out but will be included as the indexes are migrated to AWS.
3. Just because the fields are in the index doesn't imply they will be displayed in the Experts facetview gui.
4. Immediate next step after this PR is deployed is to redirect production Experts publications to point to the AWS Elasticsearch indexes being worked on in ticket https://cu-oda.atlassian.net/browse/EXPDIR-171. When that is complete the sensitive fields will be uncommented.

Usage:

The 2 main scripts which run this are: 
1.  rebuild-pubs.sh which builds the index on prometheus and is currently serving experts.colorado.edu/publications
2.  rebuild-pubs-aws.sh which builds the experts direct index in AWS and is used by CIRES and IBS. Ultimately this will also serve the experts.colorado.edu/publications page. See ticket: https://cu-oda.atlassian.net/browse/EXPDIR-171 for more details regarding this.

Note - for you python people @ulgu3559 this code was all written in python 2.6. Once we move processing to the cythna RHEL7 system we can run this in python 3.x
An example of this is the load-data.py script which runs in python 3.x on the cythna RHEL7 system. This does the AWS boto stuff.