### PR TITLE
Expdir 160

### DIFF
--- a/ingest/ingest-publications-aws.py
+++ b/ingest/ingest-publications-aws.py
@@ -159,6 +159,34 @@ def get_research_areas(person):
         .filter(has_label) \
         .map(lambda r: {"uri": r.identifier, "name": r.label()}).list()
 
+def get_website(pub):
+    weblinks = []
+
+    websites = Maybe.of(pub).stream() \
+        .flatmap(lambda p: p.objects(OBO.ARG_2000028)) \
+        .flatmap(lambda v: v.objects(VCARD.hasURL)) \
+        .filter(lambda o: has_type(o,VCARD.URL)).list()
+
+    for website in websites:
+        print("website", website )
+
+        webname = Maybe.of(website).stream() \
+           .filter(has_label) \
+           .map(lambda t: str(t.label())) \
+           .filter(non_empty_str) \
+           .one().value[0]
+        print("webname", webname)
+
+        weburl = Maybe.of(website).stream() \
+           .flatmap(lambda e: e.objects(VCARD.url)) \
+           .map(lambda r: r.value) \
+           .one().value
+        print("weburl", weburl)
+
+        if weburl:
+           weblinks.append({"name": webname, "uri": weburl})
+
+    return weblinks
 
 def get_organizations(person):
 
@@ -260,6 +288,11 @@ def create_publication_doc(pubgraph,publication):
         logging.debug('found cuscholar: %s', cuscholar)
         doc.update({"cuscholar": cuscholar})
         doc.update({"cuscholarexists": "CU Scholar"})
+
+    website = get_website(pub)
+    if website:
+        doc.update({"OpenAccess": "Yes"})
+        doc.update({"website": website})
 
     abstract = list(pub.objects(predicate=BIBO.abstract))
     abstract = abstract[0].encode('utf-8') if abstract else None

--- a/ingest/load-data.py
+++ b/ingest/load-data.py
@@ -54,7 +54,10 @@ es = Elasticsearch(
 #print(res['result'])
 
 
+print("load-data: deleting index: ",index)
 es.indices.delete(index=index, ignore=[400, 404])
+
+print("looking for files matching pattern: ",bulkfiles)
 
 for f in glob.iglob(bulkfiles):
   print("File: ",f)

--- a/ingest/rebuild-people-aws.sh
+++ b/ingest/rebuild-people-aws.sh
@@ -1,0 +1,34 @@
+# get counts of index prior to deletion
+. ./vivoapipw.py
+dstamp=`date +%Y%m%d-%H%M%S`
+outdir="spool/${dstamp}"
+indexname=$PEOPLEINDEX
+mkdir spool/$dstamp
+logfile="spool/${dstamp}/rebuild-index.out"
+outputfile="fispeople.idx"
+fullpathoutputfile="spool/${dstamp}/${outputfile}"
+echo "CREATING ES DOCUMENTS" # > $logfile
+python ./ingest-people.py --index ${indexname} --sparql ${ENDPOINT} --thread=8 $fullpathoutputfile   >> $logfile 2>&1
+EXITCODE=$?
+if [ $EXITCODE -ne 0 ]
+then
+  echo "NON ZERO EXITCODE: $EXITCODE" >>$logfile 2>&1
+  cat $logfile | mailx -s "Error: rebuild-people.sh - ingest-people.py error" elsborg@colorado.edu
+  exit
+fi
+
+outputsize=`wc -l $fullpathoutputfile | awk  '{print $1}'`
+echo "$outputsize lines in $fullpathoutputfile"
+if [ $outputsize -lt 1900 ]
+then
+  echo "Not enough lines in output. Amount of lines: $outputsize. File: ${outdir}/$indexname" >>$logfile 2>&1
+  cat $logfile | mailx -s "Error: rebuild-people.sh - not enough lines in json output" elsborg@colorado.edu
+  exit
+fi
+
+#DRE ./idx_get_count.sh ${indexname} >> $logfile
+python load-data.py --spooldir ${outdir} --esendpoint ${PRODESENDPOINT} --esuser ${ESUSER} --espass ${ESPASS} --esservice ${ESSERVICE} --esregion ${ESREGION} --index ${indexname} --out $outputfile >> $logfile 2>&1
+sleep 5
+echo "load-data.py finished: `date +%Y%m%d-%H%M%S`" >> $logfile 2>&1
+echo "Index counts after run" >> $logfile
+./idx_get_count.sh >> $logfile 2>&1

--- a/ingest/rebuild-pubs-aws.sh
+++ b/ingest/rebuild-pubs-aws.sh
@@ -27,7 +27,7 @@ then
 fi
 
 ./idx_get_count.sh $indexname >> $logfile
-python load-data.py --spooldir ${outdir} --esendpoint ${PRODESENDPOINT} --esuser ${ESUSER} --espass ${ESPASS} --esservice ${ESSERVICE} --esregion ${ESREGION} --index ${PUBSINDEX} allpubs.idx >> $logfile 2>&1
+python load-data.py --spooldir ${outdir} --esendpoint ${PRODESENDPOINT} --esuser ${ESUSER} --espass ${ESPASS} --esservice ${ESSERVICE} --esregion ${ESREGION} --index ${PUBSINDEX} --out allpubs.idx >> $logfile 2>&1
 
 sleep 5 
 echo "load-data.py finished: `date +%Y%m%d-%H%M%S`" >> $logfile 2>&1

--- a/ingest/reload-people-aws.sh
+++ b/ingest/reload-people-aws.sh
@@ -1,0 +1,14 @@
+# get counts of index prior to deletion
+. ./vivoapipw.py
+dstamp=20210825-101139
+outdir="spool/${dstamp}"
+indexname=$PEOPLEINDEX
+#mkdir spool/$dstamp
+outputfile="fispeople"
+logfile="spool/${dstamp}/rebuild-index.out"
+echo "CREATING ES DOCUMENTS" # > $logfile
+#./idx_get_count.sh ${indexname} #>> $logfile
+python load-data.py --spooldir ${outdir} --esendpoint ${PRODESENDPOINT} --esuser ${ESUSER} --espass ${ESPASS} --esservice ${ESSERVICE} --esregion ${ESREGION} --index ${indexname} --out $outputfile #DRE >> $logfile 2>&1
+sleep 10
+echo "Index counts after run" #>> $logfile
+./idx_get_count.sh #>> $logfile 2>&1


### PR DESCRIPTION
Changes strictly to the AWS Elasticsearch endpoints.
People page is now created and should be identical to the prometheus endpoint.
Also added the unpaywall additions to the publications page.
The AWS loads are running on vivo@cythna ( production ) now.